### PR TITLE
drop git-all in favor of git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
         make \
         shellcheck \
         libffi6 \
-        git-all \
+        git \
     && bundle config --global silence_root_warning 1
 
 COPY entrypoint.sh /


### PR DESCRIPTION
'git-all' brings in nearly 500mb of deps, including UI toolkits.
'git' is sufficient