### PR TITLE
Simplify token management

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+
 
   
         

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ jobs:
     # Standard usage
     - uses: ./ 
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
     
     # Specify the Jekyll source location as a parameter
     - uses: ./
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
       with:
         jekyll_src: 'sample_site'
 ```
@@ -76,4 +76,4 @@ Just click on the *_View deployment_* button of the `github-pages` environment t
 ![image](https://user-images.githubusercontent.com/2787414/51083411-188d1b00-171a-11e9-9a25-f8b06f33053e.png)
 
 ### Known Limitation
-Publishing of the GitHub pages can fail when using the `GITHUB_TOKEN` secret instead of the `JEKYLL_PAT`. But it might work too :smile: 
+Publishing of the GitHub pages can fail when using the `GITHUB_TOKEN` secret as the value of the `JEKYLL_PAT` env variable, as opposed to a Personnal Access Token set as a secret. But it might work too :smile: 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,12 +26,6 @@ cd build
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll
 
-if [[ -z "${JEKYLL_PAT}" ]]; then
-  TOKEN=${GITHUB_TOKEN}
-else 
-  TOKEN=${JEKYLL_PAT}
-fi
-
 # Is this a regular repo or an org.github.io type of repo
 if [[ "${GITHUB_REPOSITORY}" == *".github.io"* ]]; then
   remote_branch="master"
@@ -46,7 +40,7 @@ fi
 
 echo "Publishing to ${GITHUB_REPOSITORY} on branch ${remote_branch}"
 
-remote_repo="https://${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
+remote_repo="https://${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git" && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \


### PR DESCRIPTION
Only use the `JEKYLL_PAT` env variable. Users are free to use a dedicated PAT within a secret or to try their chance with `GITHUB_TOKEN`