### PR TITLE
Fixed bash-isms in entrypoint run by /bin/sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,10 +8,10 @@ bundle config path vendor/bundle
 bundle install
 echo "::debug ::Completed bundle install"
 
-if [[ ${INPUT_JEKYLL_SRC} ]]; then
+if [ -n "${INPUT_JEKYLL_SRC}" ]; then
   JEKYLL_SRC=${INPUT_JEKYLL_SRC}
   echo "::debug ::Using parameter value ${JEKYLL_SRC} as a source directory"
-elif [[ ${SRC} ]]; then
+elif [ -n "${SRC}" ]; then
   JEKYLL_SRC=${SRC}
   echo "::debug ::Using SRC environment var value ${JEKYLL_SRC} as a source directory"
 else
@@ -28,13 +28,12 @@ cd build
 touch .nojekyll
 
 # Is this a regular repo or an org.github.io type of repo
-if [[ "${GITHUB_REPOSITORY}" == *".github.io"* ]]; then
-  remote_branch="master"
-else
-  remote_branch="gh-pages"
-fi
+case "${GITHUB_REPOSITORY}" in
+  *.github.io) remote_branch="master" ;;
+  *)           remote_branch="gh-pages" ;;
+esac
 
-if [ "${GITHUB_REF}" == "refs/heads/${remote_branch}" ]; then
+if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
   echo "Cannot publish on branch ${remote_branch}"
   exit 1
 fi


### PR DESCRIPTION
`[[` is a feature of `bash`, and `entrypoint.sh` has `sh` in it's shebang. So the script dumps warning `[[: not found` somewhere and goes with wrong branch. Same goes for other tests in the script.

IIRC, Alpine doesn't have bash bundled, so simple change of shebang won't help. I suggest removing bash-specific syntax and keep with clean POSIX sh. I'm not a shell guru, so substring check for repo name can be probably done better, this is the first thing I came up with based on suffix removing via `${parameter%word}` described [here](https://pubs.opengroup.org/onlinepubs/007908775/xcu/chap2.html#tag_001_006_002).

Fixes #26.

For the record: [here's the build](https://github.com/inkremental/inkremental.github.io/runs/644514419?check_suite_focus=true#step:5:127) with current master, and here's [another one with this PR](https://github.com/inkremental/inkremental.github.io/runs/644645875?check_suite_focus=true#step:5:62). Note the lines
`Publishing to inkremental/inkremental.github.io on branch gh-pages`
and
`Publishing to inkremental/inkremental.github.io on branch master`
correspondingly.