### PR TITLE
Adding input variable for site and GemFile under sub directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,12 @@ if [ -z "${JEKYLL_PAT}" ]; then
   exit 1
 fi 
 
+#Adding input variable for site and GemFile under sub directory
+if [ -n "${INPUT_GEM_SRC}" ]; then
+  cd ${INPUT_GEM_SRC}
+  echo "::debug ::Working directory $(pwd)"
+fi
+
 echo "::debug ::Starting bundle install"
 bundle config path vendor/bundle
 bundle install


### PR DESCRIPTION
Adding support for github pages site and GemFile under subdirectory on the master branch.
Usage

`jobs:
  build:
    runs-on: ubuntu-latest
  github-pages:
    runs-on: ubuntu-16.04
    steps:
      - name: Check out master
        uses: actions/checkout@master
      - uses: actions/checkout@v2
      - uses: helaili/jekyll-action@2.0.1
        env:
          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
          INPUT_GEM_SRC: 'docs'`
