### PR TITLE
Added input property to control Jekyll root

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Note that we also renamed `index.html` to `index.adoc` and modified this file ac
 
 ### Use the action
 Use the `helaili/jekyll-action@master` action in your workflow file. It needs access to a `JEKYLL_PAT` secret set with a Personal Access Token. The directory where the Jekyll site lives will be detected (based on the location of `_config.yml`) but you can also explicitly set this directory by setting the `jekyll_src` parameter (`sample_site` for us). The `SRC` environment variable is also supported for backward compatibilty but it is deprecated.
+If your Gemfile is located in a directory other that root (for example, in docs directory of the repo), you should update `jekyll_src` input parameter accordingly.
 
 Use the `actions/cache` action in the workflow as well, to shorten build times and decrease load on GitHub's servers
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'Jekyll Actions'
 description: 'A GitHub Action to build and publish Jekyll sites to GitHub Pages'
 inputs:
+  jekyll_root:
+    description: 'Jekyll project root directory (e.g. location of Gemfile)'
+    required: false
   jekyll_src:  
     description: 'The Jekyll website source directory'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,11 @@ if [ -z "${JEKYLL_PAT}" ]; then
   exit 1
 fi 
 
+if [ -n "${INPUT_JEKYLL_ROOT}" ]; then
+  echo "::debug ::Switching to ${INPUT_JEKYLL_ROOT} as a root directory"
+  cd ${INPUT_JEKYLL_ROOT}
+fi
+
 echo "::debug ::Starting bundle install"
 bundle config path vendor/bundle
 bundle install


### PR DESCRIPTION
Current `jekyll_src` property is passed directly to Jekyll, but `Gemfile` is still expected to reside in root directory. I've got a setup where everything is located in the /docs directory, so it doesn't help us. This PR brings an additional input property, which is navigated to in the start of the shell script.

I assume our setup should be quite natural for many project, specifically those which host documentation sources within main repository and aren't Ruby-based. So I believe this addition would be beneficial for others.

I'm open to any opinions regarding other ways to support our case if this doesn't seem right to someone.