### PR TITLE
Add Node dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk add --no-cache git build-base
 # Allow for timezone setting in _config.yml
 RUN apk add --update tzdata
 
+RUN apk add --update nodejs npm
+
 # debug
 RUN bundle version
 


### PR DESCRIPTION
Hey there, thanks again for putting this action together!

I use PostCSS on my Jekyll site via [jekyll-postcss](https://github.com/mhanberg/jekyll-postcss), particularly so I can build and include TailwindCSS. When I tried to deploy, I noticed that the Jekyll build was failing due to missing Node dependency:
```
env: can't execute 'node': No such file or directory
```

I'd sort of hoped it wouldn't be necessary to modify this action, so I did first try installing Node in the GitHub action, but that failed with the same error, because the Jekyll action runs in its own container. 

This PR adds a node install step to the Dockerfile. I considered adding an Action input like `require_node` to specify the requirement explicitly and avoid unnecessary installation for the majority of Jekyll sites which (presumably) don't require Node to build. If that's something you'd like to see before merging, I'm happy to make that change and update this PR.

Thanks!