### PR TITLE
Revert to Ruby 2.6 for wider compatibility with Jekyll plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:2.7-alpine
+FROM ruby:2.6-alpine
 
-LABEL version="2.0.1"
+LABEL version="2.0.3"
 LABEL repository="https://github.com/helaili/jekyll-action"
 LABEL homepage="https://github.com/helaili/jekyll-action"
 LABEL maintainer="Alain Hélaïli <helaili@github.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL repository="https://github.com/helaili/jekyll-action"
 LABEL homepage="https://github.com/helaili/jekyll-action"
 LABEL maintainer="Alain Hélaïli <helaili@github.com>"
 
-RUN apk add --no-cache git build-base
+RUN apk add --no-cache git build-base ruby-nokogiri
 # Allow for timezone setting in _config.yml
 RUN apk add --update tzdata
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,7 @@ fi
 echo "Publishing to ${GITHUB_REPOSITORY} on branch ${remote_branch}"
 echo "::debug ::Pushing to https://${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git"
 
-remote_repo="https://${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git" && \
+remote_repo="https://x-access-token:${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git" && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \


### PR DESCRIPTION
Revert to Ruby 2.6, which has the advantage of addressing both of these issues:

- Fixes #25, removing many of the deprecation warnings caused by Ruby 2.7
- Fixes #16, as bundler 1.7.2 is the default version that ships with Ruby 2.6

While there are more flexible ways to address this, at this point GitHub Pages still runs Ruby 2.5 -- so it may be some time that Jekyll plugins are fully happy with 2.7.

Let me know what you think, Alain!

-e

