### PR TITLE
Add option to configure target branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,12 @@ jobs:
         gem_src: sample_site_gemfiles
       env:
         JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+    - name: Run with target_branch
+      uses: ./
+      with: 
+        target_branch: my_gh_pages_branch
+      env:
+        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
     - name: Basic run
       uses: ./
       env:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A GitHub Action to build and publish Jekyll sites to GitHub Pages
 Out-of-the-box Jekyll with GitHub Pages allows you to leverage a limited, white-listed, set of gems. Complex sites requiring custom ones or non white-listed ones (AsciiDoc for intstance) used to require a continuous integration build in order to pre-process the site.
 
 Remember that GitHub is serving your built static site, not it's sources. So when configuring GitHub Pages in your project settings, use **gh-pages branch** as a Source for GitHub Pages. If you are setting up *username*.github.io repository, you'll have to use **master branch**, so sources can be located in another orphaned branch in the repo (which you can safely mark as default after the first publication).
+In addition to that default behaviour, you can configure the branch this plugin pushes into with the `target_branch`-option. Keep in mind to set the source branch accordingly at the GitHub Pages Settings page.
 
 Note that this is a rather simple (naive maybe) Docker based action. @limjh16 has created [a JS based version of this action](https://github.com/limjh16/jekyll-action-ts) which saves the container download time and might help with non default use cases. 
 
@@ -81,6 +82,13 @@ jobs:
         JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
       with:
         jekyll_src: 'sample_site'
+
+    # Specify the target branch (optional)
+    - uses: helaili/jekyll-action@2.0.3
+      env:
+        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+      with:
+        target_branch: 'gh-pages'
 ```
 
 Upon successful execution, the GitHub Pages publishing will happen automatically and will be listed on the *_environment_* tab of your repository. 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   gem_src:
     description: 'The Jekyll Gemfile directory'
     required: false
+  target_branch:
+    description: 'The target branch name the sources get pushed to'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,11 +72,17 @@ cd build
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll
 
-# Is this a regular repo or an org.github.io type of repo
-case "${GITHUB_REPOSITORY}" in
-  *.github.io) remote_branch="master" ;;
-  *)           remote_branch="gh-pages" ;;
-esac
+
+if [ -n "${INPUT_TARGET_BRANCH}" ]; then
+  remote_branch="${INPUT_TARGET_BRANCH}"
+  echo "::debug::target branch is set via input parameter"
+else
+  # Is this a regular repo or an org.github.io type of repo
+  case "${GITHUB_REPOSITORY}" in
+    *.github.io) remote_branch="master" ;;
+    *)           remote_branch="gh-pages" ;;
+  esac
+fi
 
 if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
   echo "::error::Cannot publish on branch ${remote_branch}"


### PR DESCRIPTION
After running into an issue with my page and some research I came across https://github.com/helaili/jekyll-action/issues/45 and downgraded the plugin (2.0.1) for my repo to get it working.

With being able to configure the target-branch for the compiled Jekyll page it's possible to work inside the `master`-branch in repositories named `<user>.github.io`.

The user would need to set the source branch inside the config correspondingly. As I'm using v2.0.1 the action uses `gh-pages` also for `<user>.github.io`, but in general I would be able to use any other name then.
![grafik](https://user-images.githubusercontent.com/8954985/90978113-75ce8c80-e54b-11ea-8834-54425c966366.png)
