### PR TITLE
Bump the version number in the examples to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,19 @@ jobs:
           ${{ runner.os }}-gems-
 
     # Standard usage
-    - uses:  helaili/jekyll-action@2.0.3
+    - uses:  helaili/jekyll-action@2.0.4
       env:
         JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
 
     # Specify the Jekyll source location as a parameter
-    - uses: helaili/jekyll-action@2.0.3
+    - uses: helaili/jekyll-action@2.0.4
       env:
         JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
       with:
         jekyll_src: 'sample_site'
 
     # Specify the target branch (optional)
-    - uses: helaili/jekyll-action@2.0.3
+    - uses: helaili/jekyll-action@2.0.4
       env:
         JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
       with:


### PR DESCRIPTION
Got a bit confused when the `target_branch` param wasn't accepted after I copied and pasted the example. Turns out it needs to be on the latest release version.