### PR TITLE
add gsl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL repository="https://github.com/helaili/jekyll-action"
 LABEL homepage="https://github.com/helaili/jekyll-action"
 LABEL maintainer="Alain Hélaïli <helaili@github.com>"
 
-RUN apk add --no-cache git build-base
+RUN apk add --no-cache git build-base gsl-dev
 # Allow for timezone setting in _config.yml
 RUN apk add --update tzdata
 


### PR DESCRIPTION
this additional package will allow users to use https://rubygems.org/gems/gsl which improves A LOT the time used to run LSI, https://frankindev.com/2019/11/21/enable-related-posts-with-lsi/ , on my case it went from >6hrs to 10secs in ~300 posts