### PR TITLE
Run pre-build commands in Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ The target branch name the sources get pushed to
 ### build_only
 When set to `true`, the Jekyll site will be built but not published
 
+### pre_build_commands
+Commands to run prior to build and deploy. Useful for ensuring build dependencies are up to date or installing new dependencies. For example, use `apk --update add imagemagick` to install ImageMagick.
+
 ## Known Limitation
 Publishing of the GitHub pages can fail when using the `GITHUB_TOKEN` secret as the value of the `JEKYLL_PAT` env variable, as opposed to a Personal Access Token set as a secret. But it might work too :smile:
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,13 @@ inputs:
   build_only:
     description: 'Will build the Jekyll site without publishing it'
     required: false
+  pre_build_commands:
+    description: >
+      Commands to run prior to build and deploy. Useful for
+      ensuring build dependencies are up to date or installing 
+      new dependencies. For example, use `apk --update add 
+      imagemagick` to install ImageMagick.
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+echo "Execute pre-build commands specified by the user."
+[ ! -z "$INPUT_PRE_BUILD_COMMANDS" ] && eval "$INPUT_PRE_BUILD_COMMANDS"
+
 echo "Starting the Jekyll Action"
 
 if [ -z "${JEKYLL_PAT}" ]; then


### PR DESCRIPTION
ImageMagick is a necessary dependency for the jekyll_picture_tag plugin. It needs to be installed within the Docker container prior to building the Jekyll site.

This is how you use the change:
https://github.com/jamejone/jamejone.github.io/blob/master/.github/workflows/build-and-deploy.yml