### PR TITLE
Use GitHub token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,8 +229,6 @@ jobs:
         jekyll_build_options: "--config ../sample_site/_config.yml,../sample_site/_config_build_only.yml"
         jekyll_env: development
         build_only: true
-      env:
-        JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
 
   build-only-test: 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         build_only: false
         pre_build_commands: apk --update add imagemagick nodejs
       env:
-        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+        JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
       
   basic-test: 
     runs-on: ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
       with:
-        github-token: ${{secrets.JEKYLL_PAT}}
+        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           await github.repos.updateInformationAboutPagesSite({
             owner: context.repo.owner,
@@ -94,7 +94,7 @@ jobs:
         target_branch: jekyll_src_test_pages_branch
         jekyll_env: production
       env:
-        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+        JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
         JEKYLL_DEBUG: true
       
   jekyll-src-test: 
@@ -104,7 +104,7 @@ jobs:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
       with:
-        github-token: ${{secrets.JEKYLL_PAT}}
+        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           await github.repos.updateInformationAboutPagesSite({
             owner: context.repo.owner,
@@ -163,7 +163,7 @@ jobs:
         gem_src: sample_site_gemfiles
         target_branch: jekyll_gem_src_test_pages_branch
       env:
-        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+        JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
       
   jekyll-gem-src-test: 
     runs-on: ubuntu-latest
@@ -172,7 +172,7 @@ jobs:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
       with:
-        github-token: ${{secrets.JEKYLL_PAT}}
+        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           await github.repos.updateInformationAboutPagesSite({
             owner: context.repo.owner,
@@ -230,7 +230,7 @@ jobs:
         jekyll_env: development
         build_only: true
       env:
-        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+        JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
 
   build-only-test: 
     runs-on: ubuntu-latest
@@ -239,7 +239,7 @@ jobs:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
       with:
-        github-token: ${{secrets.JEKYLL_PAT}}
+        github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           await github.repos.updateInformationAboutPagesSite({
             owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,7 @@ jobs:
         jekyll_env: development
         build_only: false
         pre_build_commands: apk --update add imagemagick nodejs
-      env:
-        JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
       
   basic-test: 
     runs-on: ubuntu-latest
@@ -162,8 +161,7 @@ jobs:
         jekyll_src: sample_site
         gem_src: sample_site_gemfiles
         target_branch: jekyll_gem_src_test_pages_branch
-      env:
-        JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
       
   jekyll-gem-src-test: 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
+        github-token: ${{secrets.JEKYLL_PAT}} # Need a PAT to switch the branch
         script: |
           await github.repos.updateInformationAboutPagesSite({
             owner: context.repo.owner,
@@ -104,7 +104,7 @@ jobs:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
+        github-token: ${{secrets.JEKYLL_PAT}} # Need a PAT to switch the branch
         script: |
           await github.repos.updateInformationAboutPagesSite({
             owner: context.repo.owner,
@@ -172,7 +172,7 @@ jobs:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
+        github-token: ${{secrets.JEKYLL_PAT}} # Need a PAT to switch the branch
         script: |
           await github.repos.updateInformationAboutPagesSite({
             owner: context.repo.owner,
@@ -239,7 +239,7 @@ jobs:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
+        github-token: ${{secrets.JEKYLL_PAT}} # Need a PAT to switch the branch
         script: |
           await github.repos.updateInformationAboutPagesSite({
             owner: context.repo.owner,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ asciidoctor:
 Note that we also renamed `index.html` to `index.adoc` and modified this file accordingly in order to leverage AsciiDoc.
 
 ### Use the action
-Use the `helaili/jekyll-action@master` action in your workflow file. It needs access to a `JEKYLL_PAT` secret set with a Personal Access Token (needs ` public_repo` scope). The directory where the Jekyll site lives will be detected (based on the location of `_config.yml`) but you can also explicitly set this directory by setting the `jekyll_src` parameter (`sample_site` for us). The `SRC` environment variable is also supported for backward compatibilty but it is deprecated.
+Use the `helaili/jekyll-action@master` action in your workflow file. It needs access to the out-of-the-box `GITHUB_TOKEN` secret. The directory where the Jekyll site lives will be detected (based on the location of `_config.yml`) but you can also explicitly set this directory by setting the `jekyll_src` parameter (`sample_site` for us). The `SRC` environment variable is also supported for backward compatibilty but it is deprecated.
 The action will search for Gemfile location. If your want to specify it explicitly (e.g. if you have multiple Gemfiles per project), you should update `gem_src` input parameter accordingly.
 
 Use the `actions/cache` action in the workflow as well, to shorten build times and decrease load on GitHub's servers
@@ -72,21 +72,19 @@ jobs:
 
     # Standard usage
     - uses:  helaili/jekyll-action@v2
-      env:
-        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     # Specify the Jekyll source location as a parameter
     - uses: helaili/jekyll-action@v2
-      env:
-        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         jekyll_src: 'sample_site'
 
     # Specify the target branch (optional)
     - uses: helaili/jekyll-action@v2
-      env:
-        JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         target_branch: 'gh-pages'
 ```
 
@@ -99,6 +97,9 @@ Just click on the *_View deployment_* button of the `github-pages` environment t
 ![image](https://user-images.githubusercontent.com/2787414/51083411-188d1b00-171a-11e9-9a25-f8b06f33053e.png)
 
 ## Inputs
+
+### token
+The `GITHUB_TOKEN` secret. This is mandatory unless `build_only` is set to `true`. 
 
 ### jekyll_env
 The Jekyll environment to build (default to `production`)
@@ -121,8 +122,8 @@ When set to `true`, the Jekyll site will be built but not published
 ### pre_build_commands
 Commands to run prior to build and deploy. Useful for ensuring build dependencies are up to date or installing new dependencies. For example, use `apk --update add imagemagick` to install ImageMagick.
 
-## Known Limitation
-Publishing of the GitHub pages can fail when using the `GITHUB_TOKEN` secret as the value of the `JEKYLL_PAT` env variable, as opposed to a Personal Access Token set as a secret. But it might work too :smile:
+## Deprecation
+This action previously used a `JEKYLL_PAT` environment variable instead of the `token` parameter. This is now depreacted. 
 
 ## I have a problem
 Create a `ACTIONS_STEP_DEBUG` secret with value `true` and run the workflow again. 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'Jekyll Actions'
 description: 'A GitHub Action to build and publish Jekyll sites to GitHub Pages'
 inputs:
+  token:
+    description: 'The GITHUB_TOKEN secret'
+    required: false
   jekyll_env:
     description: 'The Jekyll environment to build'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,12 +8,12 @@ if [ -n "$INPUT_PRE_BUILD_COMMANDS" ]; then
   eval "$INPUT_PRE_BUILD_COMMANDS"
 fi 
 
-if [ -z "${INPUT_TOKEN}" && -n "${JEKYLL_PAT}"]; then
+if [ -z "${INPUT_TOKEN}" -a -n "${JEKYLL_PAT}"]; then
   echo "::warning::The JEKYLL_PAT environment variable is deprecated. Please use the token parameter"
   INPUT_TOKEN=${JEKYLL_PAT}
 fi
 
-if [ -z "${INPUT_TOKEN}" && "${INPUT_BUILD_ONLY}" != true ]; then
+if [ -z "${INPUT_TOKEN}" -a "${INPUT_BUILD_ONLY}" != true ]; then
   echo "::error::No token provided. Please set the token parameter."
   exit 1
 fi 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,9 +106,9 @@ if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
 fi
 
 echo "Publishing to ${GITHUB_REPOSITORY} on branch ${remote_branch}"
-echo "::debug::Pushing to https://${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+echo "::debug::Pushing to https://${GITHUB_ACTOR}:${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git"
 
-remote_repo="https://${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git" && \
+remote_repo="https://${GITHUB_ACTOR}:${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git" && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,12 +8,12 @@ if [ -n "$INPUT_PRE_BUILD_COMMANDS" ]; then
   eval "$INPUT_PRE_BUILD_COMMANDS"
 fi 
 
-if [ -z "${INPUT_TOKEN}" -a -n "${JEKYLL_PAT}"]; then
+if [ -z "${INPUT_TOKEN}" ] && [ -n "${JEKYLL_PAT}" ]; then
   echo "::warning::The JEKYLL_PAT environment variable is deprecated. Please use the token parameter"
   INPUT_TOKEN=${JEKYLL_PAT}
 fi
 
-if [ -z "${INPUT_TOKEN}" -a "${INPUT_BUILD_ONLY}" != true ]; then
+if [ -z "${INPUT_TOKEN}" ] && [ "${INPUT_BUILD_ONLY}" != true ]; then
   echo "::error::No token provided. Please set the token parameter."
   exit 1
 fi 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,13 @@ if [ -n "$INPUT_PRE_BUILD_COMMANDS" ]; then
   eval "$INPUT_PRE_BUILD_COMMANDS"
 fi 
 
-if [ -z "${JEKYLL_PAT}" ]; then
-  echo "::error::No token provided. Please set the JEKYLL_PAT environment variable."
+if [ -z "${INPUT_TOKEN}" && -n "${JEKYLL_PAT}"]; then
+  echo "::warning::The JEKYLL_PAT environment variable is deprecated. Please use the token parameter"
+  INPUT_TOKEN=${JEKYLL_PAT}
+fi
+
+if [ -z "${INPUT_TOKEN}" && "${INPUT_BUILD_ONLY}" != true ]; then
+  echo "::error::No token provided. Please set the token parameter."
   exit 1
 fi 
 
@@ -106,9 +111,9 @@ if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
 fi
 
 echo "Publishing to ${GITHUB_REPOSITORY} on branch ${remote_branch}"
-echo "::debug::Pushing to https://${GITHUB_ACTOR}:${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+echo "::debug::Pushing to https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-remote_repo="https://${GITHUB_ACTOR}:${JEKYLL_PAT}@github.com/${GITHUB_REPOSITORY}.git" && \
+remote_repo="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \


### PR DESCRIPTION
This PR fixes #59 and fixes #69

- Use the `GITHUB_TOKEN` instead of a custom secret
- Switch to a `token` parameter instead of the `JEKYLL_PAT` environment variable
- Accepts that the token is not set when `build_only` is set to `true`. 