### PR TITLE
allow to keep history and some previously committed files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,6 +281,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: keep_history_test_pages_branch
+    - run: | 
+        echo "<html><body>hello</body></html>" > hello.html
+        git add .
+        git commit --allow-empty -m "adding a new file"
+        git push origin keep_history_test_pages_branch
+    - uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:
         path: sample_site_gemfiles/vendor/bundle
@@ -293,7 +301,10 @@ jobs:
         jekyll_build_options: "--config ../sample_site/_config.yml,../sample_site/_config_keep_history.yml"
         jekyll_src: sample_site
         target_branch: keep_history_test_pages_branch
+        keep_history: true
         token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2
+
       
   keep-history-test: 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,7 +277,7 @@ jobs:
         name: cypress-videos-${{ runner.os }}-${{ matrix.node-version }}
         path: tests/e2e/videos
   
-  keep-history-publish: 
+  keep-history-prepare: 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -290,7 +290,11 @@ jobs:
         git add .
         git commit --allow-empty -m "adding a new file"
         git push origin keep_history_test_pages_branch
-        rm -rf *
+  
+  keep-history-publish: 
+    runs-on: ubuntu-latest
+    needs: keep-history-prepare
+    steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,6 +285,8 @@ jobs:
         ref: keep_history_test_pages_branch
     - run: | 
         echo "<html><body>hello</body></html>" > hello.html
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" 
         git add .
         git commit --allow-empty -m "adding a new file"
         git push origin keep_history_test_pages_branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,11 +284,11 @@ jobs:
       with:
         ref: keep_history_test_pages_branch
     - run: | 
-        echo "<html><body>hello</body></html>" > hello.html
+        echo "<html><body><p>hello</p><p>${GITHUB_RUN_ID}</p></body></html>" > hello.html
         git config user.name "${GITHUB_ACTOR}"
         git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" 
-        git add .
-        git commit --allow-empty -m "adding a new file"
+        git add hello.html
+        git commit -m "adding a new file"
         git push origin keep_history_test_pages_branch
   
   keep-history-publish: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,3 +276,72 @@ jobs:
       with:
         name: cypress-videos-${{ runner.os }}-${{ matrix.node-version }}
         path: tests/e2e/videos
+  
+  keep-history-publish: 
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: sample_site_gemfiles/vendor/bundle
+        key: gems-${{ hashFiles('**/Gemfile') }}
+        restore-keys: |
+          gems
+    - name: Keep history run
+      uses: ./
+      with:
+        jekyll_build_options: "--config ../sample_site/_config.yml,../sample_site/_config_keep_history.yml"
+        jekyll_src: sample_site
+        target_branch: keep_history_test_pages_branch
+        token: ${{ secrets.GITHUB_TOKEN }}
+      
+  keep-history-test: 
+    runs-on: ubuntu-latest
+    needs: build-only-test
+    steps:
+    - name: Set the GH Pages branch
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.JEKYLL_PAT}} # Need a PAT to switch the branch
+        script: |
+          await github.repos.updateInformationAboutPagesSite({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            source: {
+              branch: "keep_history_test_pages_branch",
+              path: "/"
+            }
+          })
+          await github.repos.requestPagesBuild({
+            owner: context.repo.owner,
+            repo: context.repo.repo
+          })
+    - uses: actions/checkout@v2
+    - name: Caching
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: Cypress run
+      uses: cypress-io/github-action@v2.7.2
+      with:
+        config: baseUrl=https://helaili.github.io
+        working-directory: tests/e2e
+        spec: cypress/integration/keep_history/**/*
+    - name: Save Cypress Screenshots
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: cypress-screenshots-${{ runner.os }}-${{ matrix.node-version }}
+        path: tests/e2e/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+    - name: Save Cypress Videos
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: cypress-videos-${{ runner.os }}-${{ matrix.node-version }}
+        path: tests/e2e/videos
+
+  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       
   basic-test: 
     runs-on: ubuntu-latest
-    needs: [basic-publish, jekyll-src-publish, jekyll-gem-src-publish]
+    needs: [basic-publish, jekyll-src-publish, jekyll-gem-src-publish, keep-history-publish]
     steps:
     - name: Set the GH Pages branch
       uses: actions/github-script@v3
@@ -290,6 +290,7 @@ jobs:
         git add .
         git commit --allow-empty -m "adding a new file"
         git push origin keep_history_test_pages_branch
+        rm -rf *
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,8 +310,6 @@ jobs:
         target_branch: keep_history_test_pages_branch
         keep_history: true
         token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v2
-
       
   keep-history-test: 
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ When set to `true`, the Jekyll site will be built but not published
 ### pre_build_commands
 Commands to run prior to build and deploy. Useful for ensuring build dependencies are up to date or installing new dependencies. For example, use `apk --update add imagemagick` to install ImageMagick.
 
+### keep_history 
+When set to `true`, previous version of the site will be restored before the Jekyll build takes place. You can then use [the `keep_files` option](https://jekyllrb.com/docs/configuration/options/#global-configuration) in your `_config.yml` file to select the files you want to keep. Make sure you then keep at least the `.git` folder. This option will also remove the `--force` flag from the `git commit...` command.  
+
+```yml
+keep_files: [.git, hello.html]
+```
+
 ## Deprecation
 This action previously used a `JEKYLL_PAT` environment variable instead of the `token` parameter. This is now depreacted. 
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   build_only:
     description: 'Will build the Jekyll site without publishing it'
     required: false
+  keep_history:
+    description: 'Do not overwrite whatever was already published on the target branch'
+    required: false
   pre_build_commands:
     description: >
       Commands to run prior to build and deploy. Useful for

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,6 +80,9 @@ REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITO
 echo "::debug::Remote is ${REMOTE_REPO}"
 BUILD_DIR="${GITHUB_WORKSPACE}/../jekyll_build"
 echo "::debug::Build dir is ${BUILD_DIR}"
+LOCAL_BRANCH=$remote_branch
+#LOCAL_BRANCH="master"
+echo "::debug::Local branch is ${LOCAL_BRANCH}"
 
 mkdir ${BUILD_DIR} 
 cd ${BUILD_DIR}
@@ -126,7 +129,7 @@ git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
 git add . && \
 git commit -m "jekyll build from Action ${GITHUB_SHA}" && \
-git push --force $REMOTE_REPO master:$remote_branch && \
+git push --force $REMOTE_REPO $LOCAL_BRANCH:$remote_branch && \
 rm -fr .git && \
 cd .. 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,8 +91,8 @@ if [ "${INPUT_KEEP_HISTORY}" = true ]; then
   COMMIT_OPTIONS="--allow-empty"
 else 
   echo "::debug::Initializing new repo"
-  git init -b $LOCAL_BRANCH
   LOCAL_BRANCH="main"
+  git init -b $LOCAL_BRANCH
   COMMIT_OPTIONS="--force"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,15 +80,22 @@ REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITO
 echo "::debug::Remote is ${REMOTE_REPO}"
 BUILD_DIR="${GITHUB_WORKSPACE}/../jekyll_build"
 echo "::debug::Build dir is ${BUILD_DIR}"
-LOCAL_BRANCH=$remote_branch
-#LOCAL_BRANCH="master"
-echo "::debug::Local branch is ${LOCAL_BRANCH}"
 
-mkdir ${BUILD_DIR} 
-cd ${BUILD_DIR}
-# git init
-echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
-git clone --branch $remote_branch $REMOTE_REPO .
+mkdir $BUILD_DIR
+cd $BUILD_DIR
+
+LOCAL_BRANCH="main"
+
+if [ "${INPUT_KEEP_HISTORY}" = true ]; then
+  echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
+  git clone --branch $remote_branch $REMOTE_REPO .
+  LOCAL_BRANCH=$remote_branch
+else 
+  echo "::debug::Initializing new repo"
+  git init -b $LOCAL_BRANCH
+fi
+
+echo "::debug::Local branch is ${LOCAL_BRANCH}"
 
 cd "${GITHUB_WORKSPACE}/${GEM_SRC}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,6 +81,20 @@ else
   echo "::debug::Jekyll debug is off"
 fi
 
+if [ -n "${INPUT_TARGET_BRANCH}" ]; then
+  remote_branch="${INPUT_TARGET_BRANCH}"
+  echo "::debug::target branch is set via input parameter"
+else
+  # Is this a regular repo or an org.github.io type of repo
+  case "${GITHUB_REPOSITORY}" in
+    *.github.io) remote_branch="master" ;;
+    *)           remote_branch="gh-pages" ;;
+  esac
+fi
+
+REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+echo "::debug::Remote is to ${REMOTE_REPO}"
+
 JEKYLL_ENV=${INPUT_JEKYLL_ENV} bundle exec ${BUNDLE_ARGS} jekyll build -s ${GITHUB_WORKSPACE}/${JEKYLL_SRC} -d build ${INPUT_JEKYLL_BUILD_OPTIONS} ${VERBOSE} 
 echo "Jekyll build done"
 
@@ -93,33 +107,19 @@ cd build
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll
 
-
-if [ -n "${INPUT_TARGET_BRANCH}" ]; then
-  remote_branch="${INPUT_TARGET_BRANCH}"
-  echo "::debug::target branch is set via input parameter"
-else
-  # Is this a regular repo or an org.github.io type of repo
-  case "${GITHUB_REPOSITORY}" in
-    *.github.io) remote_branch="master" ;;
-    *)           remote_branch="gh-pages" ;;
-  esac
-fi
-
 if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
   echo "::error::Cannot publish on branch ${remote_branch}"
   exit 1
 fi
 
 echo "Publishing to ${GITHUB_REPOSITORY} on branch ${remote_branch}"
-echo "::debug::Pushing to https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-remote_repo="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
 git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
 git add . && \
 git commit -m "jekyll build from Action ${GITHUB_SHA}" && \
-git push --force $remote_repo master:$remote_branch && \
+git push --force $REMOTE_REPO master:$remote_branch && \
 rm -fr .git && \
 cd .. 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,12 +88,14 @@ if [ "${INPUT_KEEP_HISTORY}" = true ]; then
   echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
   git clone --branch $remote_branch $REMOTE_REPO .
   LOCAL_BRANCH=$remote_branch
+  PUSH_OPTIONS=""
   COMMIT_OPTIONS="--allow-empty"
 else 
   echo "::debug::Initializing new repo"
   LOCAL_BRANCH="main"
   git init -b $LOCAL_BRANCH
-  COMMIT_OPTIONS="--force"
+  PUSH_OPTIONS="--force"
+  COMMIT_OPTIONS=""
 fi
 
 echo "::debug::Local branch is ${LOCAL_BRANCH}"
@@ -136,8 +138,8 @@ echo "Publishing to ${GITHUB_REPOSITORY} on branch ${remote_branch}"
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
 git add . && \
-git commit -m "jekyll build from Action ${GITHUB_SHA}" && \
-git push $COMMIT_OPTIONS $REMOTE_REPO $LOCAL_BRANCH:$remote_branch && \
+git commit $COMMIT_OPTIONS -m "jekyll build from Action ${GITHUB_SHA}" && \
+git push $PUSH_OPTIONS $REMOTE_REPO $LOCAL_BRANCH:$remote_branch && \
 rm -fr .git && \
 cd .. 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,10 +97,6 @@ echo "::debug::Remote is ${REMOTE_REPO}"
 BUILD_DIR="${GITHUB_WORKSPACE}/../jekyll_build"
 echo "::debug::Build dir is ${BUILD_DIR}"
 
-mkdir ${BUILD_DIR}
-cd ${BUILD_DIR}
-git init
-
 JEKYLL_ENV=${INPUT_JEKYLL_ENV} bundle exec ${BUNDLE_ARGS} jekyll build -s ${GITHUB_WORKSPACE}/${JEKYLL_SRC} -d ${BUILD_DIR} ${INPUT_JEKYLL_BUILD_OPTIONS} ${VERBOSE} 
 echo "Jekyll build done"
 
@@ -112,6 +108,9 @@ if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
   echo "::error::Cannot publish on branch ${remote_branch}"
   exit 1
 fi
+
+cd ${BUILD_DIR}
+git init
 
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,8 +94,11 @@ fi
 
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 echo "::debug::Remote is ${REMOTE_REPO}"
-BUILD_DIR="${GITHUB_WORKSPACE}/../JEKYLL_BUILD"
+BUILD_DIR="${GITHUB_WORKSPACE}/../jekyll_build"
 echo "::debug::Build dir is ${BUILD_DIR}"
+
+cd ${BUILD_DIR}
+git init
 
 JEKYLL_ENV=${INPUT_JEKYLL_ENV} bundle exec ${BUNDLE_ARGS} jekyll build -s ${GITHUB_WORKSPACE}/${JEKYLL_SRC} -d ${BUILD_DIR} ${INPUT_JEKYLL_BUILD_OPTIONS} ${VERBOSE} 
 echo "Jekyll build done"
@@ -104,19 +107,16 @@ if [ "${INPUT_BUILD_ONLY}" = true ]; then
   exit $?
 fi
 
-cd ${BUILD_DIR}
-
-# No need to have GitHub Pages to run Jekyll
-touch .nojekyll
-
 if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
   echo "::error::Cannot publish on branch ${remote_branch}"
   exit 1
 fi
 
+# No need to have GitHub Pages to run Jekyll
+touch .nojekyll
+
 echo "Publishing to ${GITHUB_REPOSITORY} on branch ${remote_branch}"
 
-git init && \
 git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
 git add . && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,6 +97,7 @@ echo "::debug::Remote is ${REMOTE_REPO}"
 BUILD_DIR="${GITHUB_WORKSPACE}/../jekyll_build"
 echo "::debug::Build dir is ${BUILD_DIR}"
 
+mkdir ${BUILD_DIR}
 cd ${BUILD_DIR}
 git init
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -112,7 +112,7 @@ fi
 cd ${BUILD_DIR}
 # git init
 echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
-git clone --branch $remote_branch $REMOTE_REPO
+git clone --branch $remote_branch $REMOTE_REPO .
 
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,17 @@ else
   INPUT_JEKYLL_ENV="production"
 fi  
 
+if [ -n "${INPUT_TARGET_BRANCH}" ]; then
+  remote_branch="${INPUT_TARGET_BRANCH}"
+  echo "::debug::target branch is set via input parameter"
+else
+  # Is this a regular repo or an org.github.io type of repo
+  case "${GITHUB_REPOSITORY}" in
+    *.github.io) remote_branch="master" ;;
+    *)           remote_branch="gh-pages" ;;
+  esac
+fi
+
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 echo "::debug::Remote is ${REMOTE_REPO}"
 BUILD_DIR="${GITHUB_WORKSPACE}/../jekyll_build"
@@ -90,17 +101,6 @@ if [ "${JEKYLL_DEBUG}" = true ]; then
   VERBOSE="--verbose"
 else 
   echo "::debug::Jekyll debug is off"
-fi
-
-if [ -n "${INPUT_TARGET_BRANCH}" ]; then
-  remote_branch="${INPUT_TARGET_BRANCH}"
-  echo "::debug::target branch is set via input parameter"
-else
-  # Is this a regular repo or an org.github.io type of repo
-  case "${GITHUB_REPOSITORY}" in
-    *.github.io) remote_branch="master" ;;
-    *)           remote_branch="gh-pages" ;;
-  esac
 fi
 
 JEKYLL_ENV=${INPUT_JEKYLL_ENV} bundle exec ${BUNDLE_ARGS} jekyll build -s ${GITHUB_WORKSPACE}/${JEKYLL_SRC} -d ${BUILD_DIR} ${INPUT_JEKYLL_BUILD_OPTIONS} ${VERBOSE} 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,17 @@ else
   INPUT_JEKYLL_ENV="production"
 fi  
 
+REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+echo "::debug::Remote is ${REMOTE_REPO}"
+BUILD_DIR="${GITHUB_WORKSPACE}/../jekyll_build"
+echo "::debug::Build dir is ${BUILD_DIR}"
+
+mkdir ${BUILD_DIR} 
+cd ${BUILD_DIR}
+# git init
+echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
+git clone --branch $remote_branch $REMOTE_REPO .
+
 cd $GEM_SRC
 
 bundle config path "$PWD/vendor/bundle"
@@ -92,11 +103,6 @@ else
   esac
 fi
 
-REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-echo "::debug::Remote is ${REMOTE_REPO}"
-BUILD_DIR="${GITHUB_WORKSPACE}/../jekyll_build"
-echo "::debug::Build dir is ${BUILD_DIR}"
-
 JEKYLL_ENV=${INPUT_JEKYLL_ENV} bundle exec ${BUNDLE_ARGS} jekyll build -s ${GITHUB_WORKSPACE}/${JEKYLL_SRC} -d ${BUILD_DIR} ${INPUT_JEKYLL_BUILD_OPTIONS} ${VERBOSE} 
 echo "Jekyll build done"
 
@@ -110,9 +116,6 @@ if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
 fi
 
 cd ${BUILD_DIR}
-# git init
-echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
-git clone --branch $remote_branch $REMOTE_REPO .
 
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -93,16 +93,18 @@ else
 fi
 
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-echo "::debug::Remote is to ${REMOTE_REPO}"
+echo "::debug::Remote is ${REMOTE_REPO}"
+BUILD_DIR="${GITHUB_WORKSPACE}/../JEKYLL_BUILD"
+echo "::debug::Build dir is ${BUILD_DIR}"
 
-JEKYLL_ENV=${INPUT_JEKYLL_ENV} bundle exec ${BUNDLE_ARGS} jekyll build -s ${GITHUB_WORKSPACE}/${JEKYLL_SRC} -d build ${INPUT_JEKYLL_BUILD_OPTIONS} ${VERBOSE} 
+JEKYLL_ENV=${INPUT_JEKYLL_ENV} bundle exec ${BUNDLE_ARGS} jekyll build -s ${GITHUB_WORKSPACE}/${JEKYLL_SRC} -d ${BUILD_DIR} ${INPUT_JEKYLL_BUILD_OPTIONS} ${VERBOSE} 
 echo "Jekyll build done"
 
 if [ "${INPUT_BUILD_ONLY}" = true ]; then
   exit $?
 fi
 
-cd build
+cd ${BUILD_DIR}
 
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,7 +110,8 @@ if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
 fi
 
 cd ${BUILD_DIR}
-git init
+# git init
+git clone --branch $remote_branch $REMOTE_REPO
 
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,6 +111,7 @@ fi
 
 cd ${BUILD_DIR}
 # git init
+echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
 git clone --branch $remote_branch $REMOTE_REPO
 
 # No need to have GitHub Pages to run Jekyll

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,7 +87,7 @@ cd ${BUILD_DIR}
 echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
 git clone --branch $remote_branch $REMOTE_REPO .
 
-cd $GEM_SRC
+cd "${GITHUB_WORKSPACE}/${GEM_SRC}"
 
 bundle config path "$PWD/vendor/bundle"
 echo "::debug::Bundle config set succesfully"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,15 +84,16 @@ echo "::debug::Build dir is ${BUILD_DIR}"
 mkdir $BUILD_DIR
 cd $BUILD_DIR
 
-LOCAL_BRANCH="main"
-
 if [ "${INPUT_KEEP_HISTORY}" = true ]; then
   echo "::debug::Cloning ${remote_branch} from repo ${REMOTE_REPO}"
   git clone --branch $remote_branch $REMOTE_REPO .
   LOCAL_BRANCH=$remote_branch
+  COMMIT_OPTIONS="--allow-empty"
 else 
   echo "::debug::Initializing new repo"
   git init -b $LOCAL_BRANCH
+  LOCAL_BRANCH="main"
+  COMMIT_OPTIONS="--force"
 fi
 
 echo "::debug::Local branch is ${LOCAL_BRANCH}"
@@ -136,7 +137,7 @@ git config user.name "${GITHUB_ACTOR}" && \
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
 git add . && \
 git commit -m "jekyll build from Action ${GITHUB_SHA}" && \
-git push --force $REMOTE_REPO $LOCAL_BRANCH:$remote_branch && \
+git push $COMMIT_OPTIONS $REMOTE_REPO $LOCAL_BRANCH:$remote_branch && \
 rm -fr .git && \
 cd .. 
 

--- a/sample_site/_config_keep_history.yml
+++ b/sample_site/_config_keep_history.yml
@@ -1,3 +1,3 @@
 title: Jekyll AsciiDoc Action - Keep history
 test_id: jekyll_src
-keep_files: [hello.html]
+keep_files: [.git, hello.html]

--- a/sample_site/_config_keep_history.yml
+++ b/sample_site/_config_keep_history.yml
@@ -1,3 +1,3 @@
 title: Jekyll AsciiDoc Action - Keep history
 test_id: jekyll_src
-keep_files: hello.html
+keep_files: [hello.html]

--- a/sample_site/_config_keep_history.yml
+++ b/sample_site/_config_keep_history.yml
@@ -1,0 +1,2 @@
+title: Jekyll AsciiDoc Action - Keep history
+test_id: jekyll_src

--- a/sample_site/_config_keep_history.yml
+++ b/sample_site/_config_keep_history.yml
@@ -1,2 +1,3 @@
 title: Jekyll AsciiDoc Action - Keep history
 test_id: jekyll_src
+keep_files: hello.html

--- a/tests/e2e/cypress/integration/keep_history/spec.js
+++ b/tests/e2e/cypress/integration/keep_history/spec.js
@@ -1,0 +1,6 @@
+it('works', () => {
+  cy.visit('/jekyll-action/')
+  cy.get('#jekyll_src').should('be.visible')
+  cy.get('body main div header h1').should('contain', 'Jekyll AsciiDoc Action - Keep history')
+  cy.get('#env').should('contain', 'production')
+})

--- a/tests/e2e/cypress/integration/keep_history/spec.js
+++ b/tests/e2e/cypress/integration/keep_history/spec.js
@@ -4,3 +4,8 @@ it('works', () => {
   cy.get('body main div header h1').should('contain', 'Jekyll AsciiDoc Action - Keep history')
   cy.get('#env').should('contain', 'production')
 })
+
+it('keeps files', () => {
+  cy.visit('/jekyll-action/hello.html')
+  cy.get('body p').should('contain', 'hello')
+})


### PR DESCRIPTION
`jekyll build` usually wipe out the target folder. We now can keep some of them and also keep commit history