### PR TITLE
Use GitHub API to detect source branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Cypress run
       uses: cypress-io/github-action@v2.7.2
       with:
-        config: baseUrl=steps.rendered-site-url.outputs.url
+        config: baseUrl=${{ steps.rendered-site-url.outputs.url }}
         working-directory: tests/e2e
         spec: cypress/integration/basic/**/*
     - name: Save Cypress Screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,12 @@ jobs:
     - name: Get the URL of the rendered site
       id: rendered-site-url
       run: |
-        url=$(curl -sH "Authorization: token ${INPUT_TOKEN}" \
+        url=$(curl -sH "Authorization: token ${AUTH_TOKEN}" \
         "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages" | \
         awk -F'"' '/\"html_url\"/ { print $4 }')
         echo "::set-output name=url::${url}"
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Cypress run
       uses: cypress-io/github-action@v2.7.2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,23 @@ jobs:
   basic-publish: 
     runs-on: ubuntu-latest
     steps:
+    - name: Set the GH Pages branch
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.JEKYLL_PAT}} # Need a PAT to switch the branch
+        script: |
+          await github.repos.updateInformationAboutPagesSite({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            source: {
+              branch: "gh-pages",
+              path: "/"
+            }
+          })
+          await github.repos.requestPagesBuild({
+            owner: context.repo.owner,
+            repo: context.repo.repo
+          })
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,10 @@ jobs:
     - name: Get the URL of the rendered site
       id: rendered-site-url
       run: |
-        url=$(curl -sH "Authorization: token ${AUTH_TOKEN}" \
+        full_url=$(curl -sH "Authorization: token ${AUTH_TOKEN}" \
         "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages" | \
         awk -F'"' '/\"html_url\"/ { print $4 }')
+        url=$(dirname "${full_url}")
         echo "::set-output name=url::${url}"
       env:
         AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,19 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+    - name: Get the URL of the rendered site
+      id: rendered-site-url
+      run: |
+        url=$(curl -sH "Authorization: token ${INPUT_TOKEN}" \
+        "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages" | \
+        awk -F'"' '/\"html_url\"/ { print $4 }')
+        echo "::set-output name=url::${url}"
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Cypress run
       uses: cypress-io/github-action@v2.7.2
       with:
-        config: baseUrl=https://helaili.github.io
+        config: baseUrl=steps.rendered-site-url.outputs.url
         working-directory: tests/e2e
         spec: cypress/integration/basic/**/*
     - name: Save Cypress Screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,6 +227,7 @@ jobs:
         jekyll_build_options: "--config ../sample_site/_config.yml,../sample_site/_config_build_only.yml"
         jekyll_env: development
         build_only: true
+        token: ${{ secrets.GITHUB_TOKEN }}
 
   build-only-test: 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,10 +135,20 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+    - name: Get the URL of the rendered site
+      id: rendered-site-url
+      run: |
+        full_url=$(curl -sH "Authorization: token ${AUTH_TOKEN}" \
+        "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages" | \
+        awk -F'"' '/\"html_url\"/ { print $4 }')
+        url=$(dirname "${full_url}")
+        echo "::set-output name=url::${url}"
+      env:
+        AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Cypress run
       uses: cypress-io/github-action@v2.7.2
       with:
-        config: baseUrl=https://helaili.github.io
+        config: baseUrl=${{ steps.rendered-site-url.outputs.url }}
         working-directory: tests/e2e
         spec: cypress/integration/jekyll_src/**/*
     - name: Save Cypress Screenshots
@@ -202,10 +212,20 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+    - name: Get the URL of the rendered site
+      id: rendered-site-url
+      run: |
+        full_url=$(curl -sH "Authorization: token ${AUTH_TOKEN}" \
+        "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages" | \
+        awk -F'"' '/\"html_url\"/ { print $4 }')
+        url=$(dirname "${full_url}")
+        echo "::set-output name=url::${url}"
+      env:
+        AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Cypress run
       uses: cypress-io/github-action@v2.7.2
       with:
-        config: baseUrl=https://helaili.github.io
+        config: baseUrl=${{ steps.rendered-site-url.outputs.url }}
         working-directory: tests/e2e
         spec: cypress/integration/jekyll_gem_src/**/*
     - name: Save Cypress Screenshots
@@ -268,10 +288,20 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+    - name: Get the URL of the rendered site
+      id: rendered-site-url
+      run: |
+        full_url=$(curl -sH "Authorization: token ${AUTH_TOKEN}" \
+        "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages" | \
+        awk -F'"' '/\"html_url\"/ { print $4 }')
+        url=$(dirname "${full_url}")
+        echo "::set-output name=url::${url}"
+      env:
+        AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Cypress run
       uses: cypress-io/github-action@v2.7.2
       with:
-        config: baseUrl=https://helaili.github.io
+        config: baseUrl=${{ steps.rendered-site-url.outputs.url }}
         working-directory: tests/e2e
         # We're not publishing so the previous test should still pass
         spec: cypress/integration/jekyll_gem_src/**/*
@@ -351,10 +381,20 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+    - name: Get the URL of the rendered site
+      id: rendered-site-url
+      run: |
+        full_url=$(curl -sH "Authorization: token ${AUTH_TOKEN}" \
+        "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages" | \
+        awk -F'"' '/\"html_url\"/ { print $4 }')
+        url=$(dirname "${full_url}")
+        echo "::set-output name=url::${url}"
+      env:
+        AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Cypress run
       uses: cypress-io/github-action@v2.7.2
       with:
-        config: baseUrl=https://helaili.github.io
+        config: baseUrl=${{ steps.rendered-site-url.outputs.url }}
         working-directory: tests/e2e
         spec: cypress/integration/keep_history/**/*
     - name: Save Cypress Screenshots

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ LABEL maintainer="Alain Hélaïli <helaili@github.com>"
 RUN apk add --no-cache git build-base
 # Allow for timezone setting in _config.yml
 RUN apk add --update tzdata
+# Use curl to send API requests
+RUN apk add --update curl
 
 # debug
 RUN bundle version


### PR DESCRIPTION
[GitHub Pages can build and deploy from any branch](https://github.blog/changelog/2020-07-31-build-and-deploy-github-pages-from-any-branch-beta/). Detecting the source branch via GitHub API is a more scalable way.

It requires token to authenticate.

Hard coded base urls in Cypress tests were also rewritten in the same way.