### PR TITLE
Add GSL LSI Support for Recommended Posts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL repository="https://github.com/helaili/jekyll-action"
 LABEL homepage="https://github.com/helaili/jekyll-action"
 LABEL maintainer="Alain Hélaïli <helaili@github.com>"
 
-RUN apk add --no-cache git build-base
+RUN apk add --no-cache git build-base gsl-dev
 # Allow for timezone setting in _config.yml
 RUN apk add --update tzdata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine
+FROM ruby:2.7-alpine3.14
 
 LABEL version="2.0.1"
 LABEL repository="https://github.com/helaili/jekyll-action"


### PR DESCRIPTION
Adds the dependency for GSL to jekyll-action. This allows adding to Gemfile:
```
       gem 'classifier-reborn'
       gem 'gsl'
```
and setting
```
lsi: true
```
in config to use autogenerated suggested posts.