### PR TITLE
Address issue #98: set CNAME file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
       new dependencies. For example, use `apk --update add 
       imagemagick` to install ImageMagick.
     required: false
+  cname:
+    description: 'contents of the CNAME file'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,6 +139,10 @@ fi
 
 cd ${BUILD_DIR}
 
+if [ -n "${INPUT_CNAME}" ]; then
+  echo $INPUT_CNAME > CNAME
+fi
+
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll
 


### PR DESCRIPTION
This PR addresses issue #98 

It allows passing the desired contents for the `CNAME` file using `cname` input for the action.

It resolves the issue of custom domain support for GitHub Pages.
