### PR TITLE
Fix example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ on:
 
 jobs:
   jekyll:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
The Ubuntu 16.04 environment will not work anymore. The new 18.04 version should be used here so the example config works out of the box.