### PR TITLE
use ubuntu-latest everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ on:
 
 jobs:
   jekyll:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
There was one occurence left of ubuntu_16.04 in the doc