### PR TITLE
Git repo data is missing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ fi
 if [ -n "${INPUT_TARGET_BRANCH}" ]; then
   remote_branch="${INPUT_TARGET_BRANCH}"
   echo "::debug::target branch is set via input parameter"
-elif [ -n "${INPUT_TOKEN}" ] && [ "${INPUT_BUILD_ONLY}" != true ]; then
+else 
   response=$(curl -sH "Authorization: token ${INPUT_TOKEN}" \
                   "https://${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages")
   remote_branch=$(echo "$response" | awk -F'"' '/\"branch\"/ { print $4 }')
@@ -78,12 +78,6 @@ elif [ -n "${INPUT_TOKEN}" ] && [ "${INPUT_BUILD_ONLY}" != true ]; then
   else 
     echo "::debug::using the branch ${remote_branch} set on the repo settings"
   fi
-else 
-  case "${GITHUB_REPOSITORY}" in
-    *.github.io) remote_branch="master" ;;
-    *)           remote_branch="gh-pages" ;;
-  esac
-  echo "::debug::resolving to ${remote_branch} with a bit of a guess. Maybe we should default to main instead of master?"
 fi
 
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,6 +121,8 @@ else
   git init -b $LOCAL_BRANCH
   PUSH_OPTIONS="--force"
   COMMIT_OPTIONS=""
+  pwd
+  ls -al
 fi
 
 echo "::debug::Local branch is ${LOCAL_BRANCH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,16 +64,10 @@ else
   INPUT_JEKYLL_ENV="production"
 fi  
 
-
-case "${GITHUB_REPOSITORY}" in
-  *.github.io) remote_branch="master" ;;
-  *)           remote_branch="gh-pages" ;;
-esac
-  
 if [ -n "${INPUT_TARGET_BRANCH}" ]; then
   remote_branch="${INPUT_TARGET_BRANCH}"
   echo "::debug::target branch is set via input parameter"
-else
+elif [ -n "${INPUT_TOKEN}" ]; then
   response=$(curl -sH "Authorization: token ${INPUT_TOKEN}" \
                   "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages")
   remote_branch=$(echo "$response" | awk -F'"' '/\"branch\"/ { print $4 }')
@@ -84,6 +78,12 @@ else
   else 
     echo "::debug::using the branch ${remote_branch} set on the repo settings"
   fi
+else 
+  case "${GITHUB_REPOSITORY}" in
+    *.github.io) remote_branch="master" ;;
+    *)           remote_branch="gh-pages" ;;
+  esac
+  echo "::debug::resolving to ${remote_branch} with a bit of a guess. Maybe we should default to main instead of master?"
 fi
 
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,10 +64,16 @@ else
   INPUT_JEKYLL_ENV="production"
 fi  
 
+
+case "${GITHUB_REPOSITORY}" in
+  *.github.io) remote_branch="master" ;;
+  *)           remote_branch="gh-pages" ;;
+esac
+  
 if [ -n "${INPUT_TARGET_BRANCH}" ]; then
   remote_branch="${INPUT_TARGET_BRANCH}"
   echo "::debug::target branch is set via input parameter"
-elif [ -n "${INPUT_TOKEN}" ]; then
+else
   response=$(curl -sH "Authorization: token ${INPUT_TOKEN}" \
                   "https://${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages")
   remote_branch=$(echo "$response" | awk -F'"' '/\"branch\"/ { print $4 }')
@@ -78,12 +84,6 @@ elif [ -n "${INPUT_TOKEN}" ]; then
   else 
     echo "::debug::using the branch ${remote_branch} set on the repo settings"
   fi
-else 
-  case "${GITHUB_REPOSITORY}" in
-    *.github.io) remote_branch="master" ;;
-    *)           remote_branch="gh-pages" ;;
-  esac
-  echo "::debug::resolving to ${remote_branch} with a bit of a guess. Maybe we should default to main instead of master?"
 fi
 
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -155,6 +155,9 @@ fi
 
 cd ${BUILD_DIR}
 
+pwd
+ls -al
+
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,9 +67,9 @@ fi
 if [ -n "${INPUT_TARGET_BRANCH}" ]; then
   remote_branch="${INPUT_TARGET_BRANCH}"
   echo "::debug::target branch is set via input parameter"
-else
+elif [ -n "${INPUT_TOKEN}" ] && [ "${INPUT_BUILD_ONLY}" != true ]; then
   response=$(curl -sH "Authorization: token ${INPUT_TOKEN}" \
-                  "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages")
+                  "https://${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages")
   remote_branch=$(echo "$response" | awk -F'"' '/\"branch\"/ { print $4 }')
   if [ -z "${remote_branch}" ]; then
     echo "::error::Cannot get GitHub Pages source branch via API."
@@ -78,6 +78,12 @@ else
   else 
     echo "::debug::using the branch ${remote_branch} set on the repo settings"
   fi
+else 
+  case "${GITHUB_REPOSITORY}" in
+    *.github.io) remote_branch="master" ;;
+    *)           remote_branch="gh-pages" ;;
+  esac
+  echo "::debug::resolving to ${remote_branch} with a bit of a guess. Maybe we should default to main instead of master?"
 fi
 
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,14 +115,6 @@ if [ "${INPUT_KEEP_HISTORY}" = true ]; then
   LOCAL_BRANCH=$remote_branch
   PUSH_OPTIONS=""
   COMMIT_OPTIONS="--allow-empty"
-else 
-  echo "::debug::Initializing new repo"
-  LOCAL_BRANCH="main"
-  git init -b $LOCAL_BRANCH
-  PUSH_OPTIONS="--force"
-  COMMIT_OPTIONS=""
-  pwd
-  ls -al
 fi
 
 echo "::debug::Local branch is ${LOCAL_BRANCH}"
@@ -156,6 +148,14 @@ if [ "${GITHUB_REF}" = "refs/heads/${remote_branch}" ]; then
 fi
 
 cd ${BUILD_DIR}
+
+if [ "${INPUT_KEEP_HISTORY}" != true ]; then
+  echo "::debug::Initializing new repo"
+  LOCAL_BRANCH="main"
+  git init -b $LOCAL_BRANCH
+  PUSH_OPTIONS="--force"
+  COMMIT_OPTIONS=""
+fi
 
 pwd
 ls -al

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -149,6 +149,7 @@ fi
 
 cd ${BUILD_DIR}
 
+# Initializing the repo now to prevent the Jekyll build from overwriting the .git folder 
 if [ "${INPUT_KEEP_HISTORY}" != true ]; then
   echo "::debug::Initializing new repo"
   LOCAL_BRANCH="main"
@@ -156,9 +157,6 @@ if [ "${INPUT_KEEP_HISTORY}" != true ]; then
   PUSH_OPTIONS="--force"
   COMMIT_OPTIONS=""
 fi
-
-pwd
-ls -al
 
 # No need to have GitHub Pages to run Jekyll
 touch .nojekyll

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,8 @@ else
   INPUT_JEKYLL_ENV="production"
 fi  
 
+# Which branch will be used for publishing? 
+# It can be provided, or dectected through API or inferred from the repo name, which is a bit of a legacy behavior.
 if [ -n "${INPUT_TARGET_BRANCH}" ]; then
   remote_branch="${INPUT_TARGET_BRANCH}"
   echo "::debug::target branch is set via input parameter"
@@ -74,17 +76,23 @@ elif [ -n "${INPUT_TOKEN}" ]; then
   if [ -z "${remote_branch}" ]; then
     echo "::error::Cannot get GitHub Pages source branch via API."
     echo "::error::${response}"
-    exit 1
   else 
     echo "::debug::using the branch ${remote_branch} set on the repo settings"
   fi
-else 
+fi
+
+# In case the remote branch was neither provided nor detected via API.
+if [ -z "${remote_branch}" ]; then
   case "${GITHUB_REPOSITORY}" in
     *.github.io) remote_branch="master" ;;
     *)           remote_branch="gh-pages" ;;
   esac
   echo "::debug::resolving to ${remote_branch} with a bit of a guess. Maybe we should default to main instead of master?"
 fi
+
+echo "Remote branch is ${remote_branch}"
+
+
 
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 echo "::debug::Remote is ${REMOTE_REPO}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ fi
 if [ -n "${INPUT_TARGET_BRANCH}" ]; then
   remote_branch="${INPUT_TARGET_BRANCH}"
   echo "::debug::target branch is set via input parameter"
-else 
+elif [ -n "${INPUT_TOKEN}" ]; then
   response=$(curl -sH "Authorization: token ${INPUT_TOKEN}" \
                   "https://${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages")
   remote_branch=$(echo "$response" | awk -F'"' '/\"branch\"/ { print $4 }')
@@ -78,6 +78,12 @@ else
   else 
     echo "::debug::using the branch ${remote_branch} set on the repo settings"
   fi
+else 
+  case "${GITHUB_REPOSITORY}" in
+    *.github.io) remote_branch="master" ;;
+    *)           remote_branch="gh-pages" ;;
+  esac
+  echo "::debug::resolving to ${remote_branch} with a bit of a guess. Maybe we should default to main instead of master?"
 fi
 
 REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,8 +74,8 @@ elif [ -n "${INPUT_TOKEN}" ]; then
                   "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages")
   remote_branch=$(echo "$response" | awk -F'"' '/\"branch\"/ { print $4 }')
   if [ -z "${remote_branch}" ]; then
-    echo "::error::Cannot get GitHub Pages source branch via API."
-    echo "::error::${response}"
+    echo "::warning::Cannot get GitHub Pages source branch via API."
+    echo "::warning::${response}"
   else 
     echo "::debug::using the branch ${remote_branch} set on the repo settings"
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,7 +75,7 @@ if [ -n "${INPUT_TARGET_BRANCH}" ]; then
   echo "::debug::target branch is set via input parameter"
 else
   response=$(curl -sH "Authorization: token ${INPUT_TOKEN}" \
-                  "https://${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages")
+                  "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages")
   remote_branch=$(echo "$response" | awk -F'"' '/\"branch\"/ { print $4 }')
   if [ -z "${remote_branch}" ]; then
     echo "::error::Cannot get GitHub Pages source branch via API."


### PR DESCRIPTION
The `git init` had been moved before the Jekyll build, which overwrite the content of the folder. Therefore the git metadata was deleted. 

Fixes #121 