### PR TITLE
Configurable gh author

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ keep_files: [.git, hello.html]
 ### bundler_version
 When set override the default bundler version provided. If not given will attempt to resolve bundler version from `Gemfile.lock` if one exists.
 
+### commit_author
+When set override the default author of the commits to be performed. The default is to use the `GITHUB_ACTOR` environment variable, which is usually the owner of the `GITHUB_TOKEN` secret. The value can for example be set to `github-actions[bot]`. The corresponding email address is automatically set to `[commit_author]@users.noreply.github.com`.
+
 ## Use case: multi version publishing 
 
 Say you want to create a documentation website where you both have the current version (`v3.0`), but also `v1.0` and `v2.0`. You can then use a combination of `keep_history` and `target_path` along with the `actions/checkout@v2`action so that each version gets pushed in a separate folder without overwritting the previous one. 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,12 @@ inputs:
   bundler_version:
     description: 'When set override the default bundler version provided.'
     required: false
+  commit_author:
+    description: >
+      Provide an author for commits by the action. 
+      The email address is automatically set to 
+      `[author name]@users.noreply.github.com`
+    required: false
 outputs:
   sha: 
     description: 'Generated commit SHA1 that will be published'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -180,8 +180,15 @@ touch .nojekyll
 
 echo "Publishing to ${GITHUB_REPOSITORY} on branch ${remote_branch}"
 
-git config user.name "${GITHUB_ACTOR}" && \
-git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
+if [ -n "$INPUT_COMMIT_AUTHOR" ]; then
+  git config user.name "${INPUT_COMMIT_AUTHOR}" && \
+  git config user.email "${INPUT_COMMIT_AUTHOR}@users.noreply.github.com" && \
+  echo "::debug::commit author is set via input parameter"
+else
+  git config user.name "${GITHUB_ACTOR}" && \
+  git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && \
+  echo "::debug::commit author is set to the default github actor"
+fi
 git add . && \
 git commit $COMMIT_OPTIONS -m "jekyll build from Action ${GITHUB_SHA}" && \
 git push $PUSH_OPTIONS $REMOTE_REPO $LOCAL_BRANCH:$remote_branch && \


### PR DESCRIPTION
resolves #141 

The PR makes the author of the commits by the action configurable. Just like @tielur mentioned in the above issue but a little more general.