### PR TITLE
Adding Python 3 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL repository="https://github.com/helaili/jekyll-action"
 LABEL homepage="https://github.com/helaili/jekyll-action"
 LABEL maintainer="Alain Hélaïli <helaili@github.com>"
 
-RUN apk add --no-cache git build-base
+RUN apk add --no-cache git build-base python3 
 # Allow for timezone setting in _config.yml
 RUN apk add --update tzdata
 # Use curl to send API requests


### PR DESCRIPTION
Python 3 is required by the Asciidoc plugin.