### PR TITLE
Add error handling for failing git push

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -190,9 +190,18 @@ else
   echo "::debug::commit author is set to the default github actor"
 fi
 git add . && \
-git commit $COMMIT_OPTIONS -m "jekyll build from Action ${GITHUB_SHA}" && \
-git push $PUSH_OPTIONS $REMOTE_REPO $LOCAL_BRANCH:$remote_branch && \
+git commit $COMMIT_OPTIONS -m "jekyll build from Action ${GITHUB_SHA}"
+
+git push $PUSH_OPTIONS $REMOTE_REPO $LOCAL_BRANCH:$remote_branch
+push_exit_code=$?
+
+if [ $push_exit_code -ne 0 ]; then
+  echo "::error::pushing to ${REMOTE_REPO} failed. Exit code: ${push_exit_code}"
+  exit $push_exit_code
+fi
+
 echo "SHA=$( git rev-parse ${LOCAL_BRANCH} )" >> $GITHUB_OUTPUT
+
 rm -fr .git && \
 cd .. 
 


### PR DESCRIPTION
The action should fail when the push to the remote repo fails. To single out the push as a cause of failure and to provide a helpful error message the chained command has been split up.

When the push fails now the action will fail with the same exit code. 

Closes #143 